### PR TITLE
BTA-350 | Migrate CtConnector code

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -41,6 +41,7 @@ class FrontendAppConfig @Inject() (override val runModeConfiguration: Configurat
 
   lazy val authUrl = baseUrl("auth")
   lazy val btaUrl = baseUrl("business-tax-account")
+  lazy val ctUrl = baseUrl("ct")
 
   lazy val loginUrl = loadConfig("urls.login")
   lazy val loginContinueUrl = loadConfig("urls.loginContinue")

--- a/app/connectors/CtConnector.scala
+++ b/app/connectors/CtConnector.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.{Inject, Singleton}
+
+import config.FrontendAppConfig
+import connectors.models.{CtAccountSummary, CtDesignatoryDetailsCollection, MicroServiceException}
+import play.api.http.Status._
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReads, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+import uk.gov.hmrc.play.http.logging.MdcLoggingExecutionContext.fromLoggingDetails
+
+import scala.concurrent.Future
+
+@Singleton
+class CtConnector @Inject()(val http: HttpClient,
+                            val config: FrontendAppConfig) {
+
+  lazy val ctUrl: String = config.ctUrl
+
+  private def handleResponse[A](uri: String)(implicit rds: HttpReads[A]): HttpReads[Option[A]] = new HttpReads[Option[A]] {
+    override def read(method: String, url: String, response: HttpResponse): Option[A] = response.status match {
+      case OK => Some(rds.read(method, url, response))
+      case NO_CONTENT | NOT_FOUND => None
+      case _ => throw MicroServiceException(
+        s"Unexpected response status: ${response.status} (possible further details: ${response.body}) for call to $uri",
+        response
+      )
+    }
+
+  }
+
+  def accountSummary(utr: String)(implicit hc: HeaderCarrier): Future[Option[CtAccountSummary]] = {
+    val uri = s"$ctUrl/ct/$utr/account-summary"
+    http.GET[Option[CtAccountSummary]](uri)(handleResponse[CtAccountSummary](uri), hc, fromLoggingDetails)
+  }
+
+  def designatoryDetails(utr: String)(implicit hc: HeaderCarrier): Future[Option[CtDesignatoryDetailsCollection]] = {
+    val uri = ctUrl + s"/ct/$utr/designatory-details"
+    http.GET[Option[CtDesignatoryDetailsCollection]](uri)(handleResponse[CtDesignatoryDetailsCollection](uri), hc, fromLoggingDetails)
+  }
+
+}

--- a/app/connectors/models/CtAccountBalance.scala
+++ b/app/connectors/models/CtAccountBalance.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class CtAccountBalance(amount: Option[BigDecimal])
+
+object CtAccountBalance {
+  implicit val formats: OFormat[CtAccountBalance] = Json.format[CtAccountBalance]
+}

--- a/app/connectors/models/CtAccountSummary.scala
+++ b/app/connectors/models/CtAccountSummary.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class CtAccountSummary(accountBalance: Option[CtAccountBalance])
+
+object CtAccountSummary {
+  implicit val formats: OFormat[CtAccountSummary] = Json.format[CtAccountSummary]
+}

--- a/app/connectors/models/CtDesignatoryDetailsCollection.scala
+++ b/app/connectors/models/CtDesignatoryDetailsCollection.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class CtDesignatoryDetailsCollection(company: Option[DesignatoryDetails] = None, communication: Option[DesignatoryDetails] = None)
+
+object CtDesignatoryDetailsCollection {
+  implicit val formats: OFormat[CtDesignatoryDetailsCollection] = Json.format[CtDesignatoryDetailsCollection]
+}

--- a/app/connectors/models/DesignatoryDetails.scala
+++ b/app/connectors/models/DesignatoryDetails.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DesignatoryDetails(name: DesignatoryDetailsName, address: Option[DesignatoryDetailsAddress] = None,
+                              contact: Option[DesignatoryDetailsContact] = None)
+
+object DesignatoryDetails {
+  implicit val formats: OFormat[DesignatoryDetails] = Json.format[DesignatoryDetails]
+}

--- a/app/connectors/models/DesignatoryDetailsAddress.scala
+++ b/app/connectors/models/DesignatoryDetailsAddress.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+
+case class DesignatoryDetailsAddress(addressLine1: Option[String] = None,
+                                     addressLine2: Option[String] = None,
+                                     addressLine3: Option[String] = None,
+                                     addressLine4: Option[String] = None,
+                                     addressLine5: Option[String] = None,
+                                     postcode: Option[String] = None,
+                                     foreignCountry: Option[String] = None)
+
+object DesignatoryDetailsAddress {
+  implicit val formats: OFormat[DesignatoryDetailsAddress] = Json.format[DesignatoryDetailsAddress]
+}

--- a/app/connectors/models/DesignatoryDetailsContact.scala
+++ b/app/connectors/models/DesignatoryDetailsContact.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DesignatoryDetailsContact(telephone: Option[DesignatoryDetailsTelephone] = None, email: Option[DesignatoryDetailsEmail] = None)
+
+object DesignatoryDetailsContact {
+  implicit val formats: OFormat[DesignatoryDetailsContact] = Json.format[DesignatoryDetailsContact]
+}

--- a/app/connectors/models/DesignatoryDetailsEmail.scala
+++ b/app/connectors/models/DesignatoryDetailsEmail.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DesignatoryDetailsEmail(primary: Option[String] = None)
+
+object DesignatoryDetailsEmail {
+  implicit val formats: OFormat[DesignatoryDetailsEmail] = Json.format[DesignatoryDetailsEmail]
+}

--- a/app/connectors/models/DesignatoryDetailsName.scala
+++ b/app/connectors/models/DesignatoryDetailsName.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DesignatoryDetailsName(nameLine1: Option[String] = None, nameLine2: Option[String] = None)
+
+object DesignatoryDetailsName {
+  implicit val formats: OFormat[DesignatoryDetailsName] = Json.format[DesignatoryDetailsName]
+}

--- a/app/connectors/models/DesignatoryDetailsTelephone.scala
+++ b/app/connectors/models/DesignatoryDetailsTelephone.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class DesignatoryDetailsTelephone(daytime: Option[String] = None, fax: Option[String] = None, evening: Option[String] = None, mobile: Option[String] = None, telephoneNumber: Option[String] = None)
+
+object DesignatoryDetailsTelephone {
+  implicit val formats: OFormat[DesignatoryDetailsTelephone] = Json.format[DesignatoryDetailsTelephone]
+}

--- a/app/connectors/models/MicroServiceException.scala
+++ b/app/connectors/models/MicroServiceException.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors.models
+
+import uk.gov.hmrc.http.HttpResponse
+
+case class MicroServiceException(message: String, response: HttpResponse) extends Exception(message)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,6 +85,11 @@ microservice {
         port = 9020
       }
 
+      ct {
+        host = localhost
+        port = 8647
+      }
+
       features {
         welsh-translation: true
       }

--- a/test/connectors/CtConnectorSpec.scala
+++ b/test/connectors/CtConnectorSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import base.SpecBase
+import connectors.models._
+import org.mockito.Matchers
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.Future
+
+class CtConnectorSpec extends SpecBase with MockitoSugar with ScalaFutures with MockHttpClient {
+
+
+  def ctConnector[A](mockedResponse: HttpResponse, httpWrapper: HttpWrapper = mock[HttpWrapper]): CtConnector = {
+    when(httpWrapper.getF[A](Matchers.any())).
+      thenReturn(mockedResponse)
+    new CtConnector(http(httpWrapper), frontendAppConfig)
+  }
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+
+  "CtConnector account summary" should {
+
+    "call the micro service with the correct uri and return the contents" in {
+
+      val ctAccountSummary = CtAccountSummary(Some(CtAccountBalance(Some(4.0))))
+
+      val response = ctConnector(
+        mockedResponse = HttpResponse(200, Some(Json.toJson(ctAccountSummary)
+        ))).accountSummary("utr")
+
+      whenReady(response) { r =>
+        r mustBe Some(ctAccountSummary)
+      }
+
+    }
+
+    "call the micro service with the correct uri and return no contents if there are none" in {
+
+      val response = ctConnector(
+        mockedResponse = HttpResponse(404, None)
+      ).accountSummary("utr")
+
+      whenReady(response) { r =>
+        r mustBe None
+      }
+    }
+
+    "call the micro service and return 500" in {
+      val ctAccountSummaryUri = "http://localhost:8647/ct/utr/account-summary"
+      val httpWrapper = mock[HttpWrapper]
+
+      val response = ctConnector(
+        mockedResponse = HttpResponse(500, None),
+        httpWrapper
+      ).accountSummary("utr")
+
+      val mse = whenReady(response.failed) { mse =>
+        mse mustBe a[MicroServiceException]
+        verify(httpWrapper).getF[CtAccountSummary](ctAccountSummaryUri)
+      }
+
+    }
+  }
+
+  val sampleDesignatoryDetails =
+    """{
+      |  "company": {
+      |    "name": {
+      |      "nameLine1": "A B",
+      |      "nameLine2": "xyz"
+      |    },
+      |    "address": {
+      |      "addressLine1": "1 Fake Street",
+      |      "addressLine2": "X",
+      |      "addressLine3": "Nowhere",
+      |      "addressLine4": "Nowhere",
+      |      "addressLine5": "Nowhere",
+      |      "postcode": "AA00 0AA",
+      |      "foreignCountry": "France"
+      |    }
+      |  },
+      |  "communication": {
+      |    "name": {
+      |      "nameLine1": "A B",
+      |      "nameLine2": "xyz"
+      |    },
+      |    "address": {
+      |      "addressLine1": "1 Fake Street",
+      |      "addressLine2": "X",
+      |      "addressLine3": "Nowhere",
+      |      "addressLine4": "Nowhere",
+      |      "addressLine5": "Nowhere",
+      |      "postcode": "AA00 0AA",
+      |      "foreignCountry": "France"
+      |    }
+      |  }
+      |}""".stripMargin
+
+  "CtConnector designatory details" should {
+
+    "Return the correct response for an example with designatory details information" in {
+
+      val response = ctConnector(
+        mockedResponse = HttpResponse(200, Some(Json.parse(sampleDesignatoryDetails)))
+      ).designatoryDetails("utr")
+
+      val expectedDetails = Some(DesignatoryDetails(
+        DesignatoryDetailsName(Some("A B"), Some("xyz")),
+        Some(DesignatoryDetailsAddress(
+          Some("1 Fake Street"),
+          Some("X"),
+          Some("Nowhere"),
+          Some("Nowhere"),
+          Some("Nowhere"),
+          Some("AA00 0AA"),
+          Some("France")
+        ))
+      ))
+
+      val expected = CtDesignatoryDetailsCollection(expectedDetails, expectedDetails)
+
+      whenReady(response) { r =>
+        r mustBe Some(expected)
+      }
+    }
+
+    "call the micro service and return 500" in {
+
+      val response = ctConnector(
+        mockedResponse = HttpResponse(500, None)
+      ).designatoryDetails("utr")
+
+      whenReady(response.failed) { mse =>
+        mse mustBe a[MicroServiceException]
+      }
+    }
+
+  }
+
+
+}

--- a/test/connectors/MockHttpClient.scala
+++ b/test/connectors/MockHttpClient.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.typesafe.config.Config
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.Writes
+import uk.gov.hmrc.http._
+import uk.gov.hmrc.http.hooks.HttpHook
+import uk.gov.hmrc.play.bootstrap.http.HttpClient
+
+import scala.concurrent.Future
+
+
+trait MockHttpClient extends MockitoSugar {
+
+
+  def http(httpWrapper: HttpWrapper) = new HttpClient {
+
+    override def doGet(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = Future.successful(httpWrapper.getF(url))
+
+    override def doPatch[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] =
+      Future.successful(httpWrapper.putF(url))
+
+    override def doPost[A](url: String, body: A, headers: Seq[(String, String)])(implicit wts: Writes[A], hc: HeaderCarrier): Future[HttpResponse] =
+      Future.successful(httpWrapper.postF(url))
+
+    override def doPostString(url: String, body: String, headers: Seq[(String, String)])(implicit hc: HeaderCarrier): Future[HttpResponse] =
+      Future.successful(httpWrapper.postF(url))
+
+    override def doEmptyPost[A](url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = Future.successful(httpWrapper.postF(url))
+
+    override def doFormPost(url: String, body: Map[String, Seq[String]])(implicit hc: HeaderCarrier): Future[HttpResponse] =
+      Future.successful(httpWrapper.postF(url))
+
+    override def doDelete(url: String)(implicit hc: HeaderCarrier): Future[HttpResponse] = Future.successful(httpWrapper.deleteF(url))
+
+    override def doPut[A](url: String, body: A)(implicit rds: Writes[A], hc: HeaderCarrier): Future[HttpResponse] =
+      Future.successful(httpWrapper.patchF(url))
+
+    override val hooks: Seq[HttpHook] = NoneRequired
+
+    override def configuration: Option[Config] = None
+  }
+
+  class HttpWrapper {
+    def getF[T](uri: String): HttpResponse = HttpResponse(200, None)
+
+    def postF[T](uri: String): HttpResponse = HttpResponse(200, None)
+
+    def putF[T](uri: String): HttpResponse = ???
+
+    def deleteF[T](uri: String): HttpResponse = ???
+
+    def patchF[T](uri: String): HttpResponse = ???
+  }
+
+}


### PR DESCRIPTION
* Migrated the code from business-tax-account with DI adjustments.
* Switched from custom enrolment code to just a string for now
* Reimplemented `HttpSugar` in the connector class like EPAYE had done.
* Added a MockHttpClient so we can test how a connector handles different response codes
